### PR TITLE
Fix service worker implementation

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,45 +1,40 @@
-diff --git a/sw.js b/sw.js
-index f7d65a4ca3badd3cf8b1df7e3484739e0bfd501f..575793bda638f2b65e68be85fb2c6e0182f3ab94 100644
---- a/sw.js
-+++ b/sw.js
-@@ -1,33 +1,34 @@
- // A simple cache-first service worker
- const CACHE_NAME = 'pgr-roster-cache-v2';
--const urlsToCache = [
--  '/',
--  'index.html',
--  'manifest.webmanifest'
--  // Icons are not cached here but can be added if you create them
--];
-+const urlsToCache = [
-+  '/',
-+  'index.html',
-+  'manifest.webmanifest',
-+  'icon-192.png',
-+  'icon-512.png'
-+];
- 
- self.addEventListener('install', event => {
-   event.waitUntil(
-     caches.open(CACHE_NAME)
-       .then(cache => {
-         console.log('Opened cache');
-         return cache.addAll(urlsToCache);
-       })
-   );
-   self.skipWaiting();
- });
- 
- self.addEventListener('activate', event => {
-   const cacheWhitelist = [CACHE_NAME];
-   event.waitUntil(
-     caches.keys().then(cacheNames => {
-       return Promise.all(
-         cacheNames.map(cacheName => {
-           if (cacheWhitelist.indexOf(cacheName) === -1) {
-             return caches.delete(cacheName);
-           }
-         })
-       );
-     })
-   );
+// A simple cache-first service worker
+const CACHE_NAME = 'pgr-roster-cache-v2';
+const urlsToCache = [
+  '/',
+  'index.html',
+  'manifest.webmanifest',
+  'icon-192.png',
+  'icon-512.png'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(urlsToCache))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  const cacheWhitelist = [CACHE_NAME];
+  event.waitUntil(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
+        cacheNames.map((cacheName) => {
+          if (!cacheWhitelist.includes(cacheName)) {
+            return caches.delete(cacheName);
+          }
+        })
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- replace sw.js with functional cache-first service worker

## Testing
- `node --check sw.js`
- ❌ `npx -p puppeteer node ...` *(module could not be found to verify service worker activation)*

------
https://chatgpt.com/codex/tasks/task_e_68c56230603c832aa53488ada501a16b