### PR TITLE
feat: show shift code in roster

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>PGR New Starter Roster Creation Tool</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="A professional tool for creating new team member training rosters for PGR at The Star Gold Coast.">
+  <meta name="description" content="A professional tool for creating new team member training rosters for PGR at The Star Gold Coast." />
   <meta name="theme-color" content="#1a1a1a" />
   <link rel="manifest" href="manifest.webmanifest">
   <link rel="apple-touch-icon" href="logo.png">
@@ -20,14 +20,14 @@
     :root {
       --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
       --font-serif: 'Cinzel', serif;
-      
+
       --bg-primary: #0e0e0e;
       --bg-secondary: #181818;
       --bg-tertiary: #242424;
       --surface: #1e1e1e;
       --surface-alt: #131313;
       --bg-gradient: radial-gradient(circle at top left, #1c1c1c 0%, #0b0b0b 100%);
-      
+
       --text-primary: #f5f5f5;
       --text-secondary: #a3a3a3;
       --text-muted: #737373;
@@ -203,7 +203,7 @@
       <div class="bd" style="padding: 0;">
         <div class="table-wrapper">
           <table id="schedTbl">
-            <thead><tr><th>Team Member</th><th>Staff ID</th><th>Date</th><th>Start</th><th>End</th><th>Outlet</th><th>Shift #</th></tr></thead>
+            <thead><tr><th>Team Member</th><th>Staff ID</th><th>Date</th><th>Start</th><th>End</th><th>Outlet</th><th>Step</th><th>Shift</th></tr></thead>
             <tbody></tbody>
           </table>
         </div>
@@ -242,7 +242,7 @@ window.onload = () => {
         "SOV South Bar": ["06:00", "10:00", "14:00", "18:00", "22:00"],
         "SOV Dining": ["17:00"]
     };
-    
+
     // --- HELPER FUNCTIONS ---
     const byId = id => document.getElementById(id);
     const pad2 = n => (n < 10 ? "0" : "") + n;
@@ -281,6 +281,26 @@ window.onload = () => {
         return count;
     }
     function canWorkThisDay(starterName, dateObj) { return shiftsInLastNDaysFor(starterName, dateObj, 10) < 8; }
+
+    function lastShiftEnd(starterName) {
+        let last = null;
+        for (const r of allRows) {
+            if (r.Starter !== starterName) continue;
+            const d = parseYMD(r.Date);
+            const [hh, mm] = r.End.split(":").map(Number);
+            d.setHours(hh, mm, 0, 0);
+            if (!last || d > last) last = d;
+        }
+        return last;
+    }
+    function hasMinRest(starterName, dateObj, startTime) {
+        const last = lastShiftEnd(starterName);
+        if (!last) return true;
+        const start = new Date(dateObj);
+        const [hh, mm] = startTime.split(":").map(Number);
+        start.setHours(hh, mm, 0, 0);
+        return (start - last) >= 12 * 60 * 60 * 1000;
+    }
 
     // --- CALENDAR FUNCTIONS ---
     function renderCalendar() {
@@ -329,16 +349,16 @@ window.onload = () => {
         byId('stName').value = ''; byId('stId').value = ''; byId('stDate').value = '';
     }
     async function clearStarters() { if (starters.length === 0) { showModal('No Starters', 'There are no starters to clear.'); return; } const confirmed = await showModal('Confirm Clear', 'Are you sure?', true); if (confirmed) { starters = []; renderStarters(); } }
-    function importStarters(e) { 
-        const f = e.target.files[0]; 
-        if (!f) return; 
-        const fr = new FileReader(); 
-        fr.onload = () => { 
-            const lines = fr.result.split(/\r?\n/).filter(Boolean); 
-            lines.shift(); 
-            starters = lines.map(l => { const [Name, StaffID, StartDate] = l.split(','); return { Name, StaffID, StartDate, blackoutDates: [] }; }); 
-            renderStarters(); 
-        }; 
+    function importStarters(e) {
+        const f = e.target.files[0];
+        if (!f) return;
+        const fr = new FileReader();
+        fr.onload = () => {
+            const lines = fr.result.split(/\r?\n/).filter(Boolean);
+            lines.shift();
+            starters = lines.map(l => { const [Name, StaffID, StartDate] = l.split(','); return { Name, StaffID, StartDate, blackoutDates: [] }; });
+            renderStarters();
+        };
         fr.readAsText(f);
         e.target.value = null;
     }
@@ -357,11 +377,11 @@ window.onload = () => {
             if (!confirmed) return;
         }
         if (!starters.length) { showModal('Build Error', 'Add at least one starter.'); return; }
-        
-        allRows = []; 
-        const placedByStarter = new Map(); 
+
+        allRows = [];
+        const placedByStarter = new Map();
         const placedByStarterOutlet = new Map();
-        
+
         function incPlaced(starterName, outlet) { placedByStarter.set(starterName, (placedByStarter.get(starterName) || 0) + 1); if (!placedByStarterOutlet.has(starterName)) placedByStarterOutlet.set(starterName, new Map()); const m = placedByStarterOutlet.get(starterName); m.set(outlet, (m.get(outlet) || 0) + 1); }
         function getPlaced(starterName) { return placedByStarter.get(starterName) || 0; }
         function getPlacedOutlet(starterName, outlet) { return placedByStarterOutlet.get(starterName)?.get(outlet) || 0; }
@@ -399,7 +419,7 @@ window.onload = () => {
                     st.currentOutlet = outlet;
                     st.remaining = Math.max(0, baseCounts[outlet] - getPlacedOutlet(s.Name, outlet));
                 }
-                while (s.blackoutDates.includes(curKey) || used.has(curKey + "|" + outlet) || !isOutletAllowedOnDate(outlet, cur) || !canWorkThisDay(s.Name, cur)) { cur = addWorkDay(cur); curKey = toYMD(cur); if (++safety > 5000) break; }
+                while (s.blackoutDates.includes(curKey) || used.has(curKey + "|" + outlet) || !isOutletAllowedOnDate(outlet, cur) || !canWorkThisDay(s.Name, cur) || !hasMinRest(s.Name, cur, pickTime(outlet, allRows.length))) { cur = addWorkDay(cur); curKey = toYMD(cur); if (++safety > 5000) break; }
                 const t = pickTime(outlet, allRows.length);
                 addRow(makeRow(s, cur, t, outlet, getPlaced(s.Name) + 1));
                 used.add(curKey + "|" + outlet);
@@ -415,7 +435,7 @@ window.onload = () => {
                 guard++; const key = toYMD(cur);
                 if (s.blackoutDates.includes(key)) { cur = addWorkDay(cur); continue; }
                 let outlet = PREF.find(o => !used.has(key + "|" + o) && isOutletAllowedOnDate(o, cur));
-                if (!outlet || !canWorkThisDay(s.Name, cur)) { cur = addWorkDay(cur); continue; }
+                if (!outlet || !canWorkThisDay(s.Name, cur) || !hasMinRest(s.Name, cur, pickTime(outlet, rot))) { cur = addWorkDay(cur); continue; }
                 const t = pickTime(outlet, rot++);
                 addRow(makeRow(s, cur, t, outlet, getPlaced(s.Name) + 1));
                 used.add(key + "|" + outlet); placed++; cur = addWorkDay(cur);
@@ -439,24 +459,24 @@ window.onload = () => {
     }
     function renderSched(rows) {
         const tb = document.querySelector('#schedTbl tbody'); tb.innerHTML = '';
-        if (rows.length === 0) { tb.innerHTML = `<tr><td colspan="7" style="text-align:center; color: var(--text-muted); padding: 2rem;">No schedule generated yet.</td></tr>`; return; }
+        if (rows.length === 0) { tb.innerHTML = `<tr><td colspan="8" style="text-align:center; color: var(--text-muted); padding: 2rem;">No schedule generated yet.</td></tr>`; return; }
         let curStarter = null;
         for (const r of rows) {
             if (r.Starter !== curStarter) {
                 curStarter = r.Starter;
                 const trHead = document.createElement('tr'); trHead.className = 'group-row';
-                trHead.innerHTML = `<td colspan="7"><b>${r.Starter}</b> &nbsp;&middot;&nbsp; <span class="text-muted">StaffID: ${r.StaffID || 'N/A'}</span></td>`;
+                trHead.innerHTML = `<td colspan="8"><b>${r.Starter}</b> &nbsp;&middot;&nbsp; <span class="text-muted">StaffID: ${r.StaffID || 'N/A'}</span></td>`;
                 tb.appendChild(trHead);
             }
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${r.Starter}</td><td>${r.StaffID || 'N/A'}</td><td>${toDMY(parseYMD(r.Date))}</td><td>${r.Start}</td><td>${r.End}</td><td>${r.Outlet}</td><td>${r.Step}</td>`;
+            tr.innerHTML = `<td>${r.Starter}</td><td>${r.StaffID || 'N/A'}</td><td>${toDMY(parseYMD(r.Date))}</td><td>${r.Start}</td><td>${r.End}</td><td>${r.Outlet}</td><td>${r.Step}</td><td>${r.Shift}</td>`;
             tb.appendChild(tr);
         }
     }
     function getBlocks() { return [{ outlet: "Oasis Food", count: Math.max(0, +byId('blk_food').value || 0) }, { outlet: "Oasis Bar", count: Math.max(0, +byId('blk_obar').value || 0) }, { outlet: "SOV South Floor", count: Math.max(3, +byId('blk_floor').value || 0) }, { outlet: "SOV North Floor", count: Math.max(0, +byId('blk_nfloor').value || 0) }, { outlet: "SOV South Bar", count: Math.max(0, +byId('blk_bar').value || 0) }, { outlet: "SOV Dining", count: Math.max(0, +byId('blk_dining').value || 0) }]; }
     function makeRow(starter, dateObj, start, outlet, step) { const [hh, mm] = start.split(":").map(Number); const endH = (hh + 5) % 24, endM = mm; return { Starter: starter.Name, StaffID: starter.StaffID || '', Date: toYMD(dateObj), Start: start, End: pad2(endH) + ":" + pad2(endM), Outlet: outlet, Step: step, Shift: start.replace(":", "") + "-" + pad2(endH) + pad2(endM) + " " + outlet + " TRN" }; }
     function pickTime(outlet, i) { const times = RULES[outlet] || ["09:00"]; return times[i % times.length]; }
-    
+
     // --- ATTACH EVENT LISTENERS ---
     byId('modal-cancel').onclick = () => { byId('modal').classList.remove('visible'); if (modalResolve) modalResolve(false); };
     byId('modal-confirm').onclick = () => { byId('modal').classList.remove('visible'); if (modalResolve) modalResolve(true); };
@@ -493,4 +513,4 @@ if("serviceWorker" in navigator && window.location.protocol === 'https:') {
   });
 }
 </script>
-</html> 
+</html>


### PR DESCRIPTION
## Summary
- close meta description tag on index page
- display shift code with outlet in generated roster table
- enforce a minimum 12-hour break between shifts when building rosters
- remove trailing whitespace in index file for clean deployment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c680be01f8832a9388e2a44da28205