### PR TITLE
Switch default competency checklist to JSON bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Flexible Workflow: Clear the generated roster with a single click to start over 
 
 Export Options: Export the final roster to both .csv and .xlsx formats for easy sharing and printing.
 
-  Configurable Session Days: Choose which weekdays host Welcome Day and PGR Onboarding.
+Competency Checklists: Load a competency template and dataset to automatically generate individualized onboarding checklists for each starter, with CSV/XLSX exports and a printable view.
+
+Configurable Session Days: Choose which weekdays host Welcome Day and PGR Onboarding.
 
 How to Use
   The application is designed around a simple, four-step workflow:
@@ -44,17 +46,34 @@ In this section, enter the number of shifts you want each new team member to com
 
 (Optional) Toggle the "Shuffle" button to ON if you want the order of the training blocks to be randomized for each person.
 
-Step 3: Select Session Days
+Step 3: Configure Competency Checklists
+
+Use the "Use Default Template" button or import your own template/dataset JSON files.
+
+Select a team member from the preview list to review their personalized competency checklist. Export all checklists (CSV/XLSX), download an individual checklist, or open a printable view that can be saved as PDF.
+
+Step 4: Select Session Days
 
 Use the dropdowns to choose which days Welcome Day and PGR Onboarding occur.
 
-Step 4: Build & Export
+Step 5: Build & Export
 
 Click the "Build Roster" button. The application will instantly generate the full schedule in the table at the bottom.
 
 Review the roster. If you made a mistake, you can click "Clear Roster" to start again.
 
 Once you are happy with the schedule, use the "Export CSV" or "Export Excel" buttons to save the file.
+
+Competency Data Bundles
+----------------------
+
+The repository ships with a default competency bundle stored in `data/`:
+
+* `pgr_competency_checklist.json` – the primary default bundle combining the template and starter dataset as JSON.
+* `data/competency-template.json` – legacy standalone template retained for backward compatibility.
+* `data/competency-dataset.json` – legacy standalone dataset retained for backward compatibility.
+
+Supervisors can import updated JSON files at runtime using the controls in **Step 3**. The importer expects valid JSON that follows the same structure as the bundled files. Each starter is matched by `staffId`, falling back to name matching when an ID is not supplied.
 
 Deployment & Installation
 This application is a self-contained web app and requires no complex setup.

--- a/data/competency-dataset.json
+++ b/data/competency-dataset.json
@@ -1,0 +1,59 @@
+{
+  "templateVersion": "2025.1",
+  "updated": "2025-01-15",
+  "defaults": {
+    "role": "Private Gaming Host",
+    "department": "Private Gaming Rooms",
+    "mentor": "TBC",
+    "context": {
+      "brand": "PGR"
+    },
+    "statusOptions": ["Not Started", "In Progress", "Complete"],
+    "defaultStatus": "Not Started"
+  },
+  "people": [
+    {
+      "name": "Dakota Parata",
+      "staffId": "123456",
+      "role": "Private Gaming Host",
+      "mentor": "Jordan Rivers",
+      "notes": "Shadow Jordan for first Sovereign shift.",
+      "competencies": {
+        "welcome-day": {"status": "Complete", "completedOn": "2025-02-03"},
+        "onboarding-pack": {"status": "Complete", "completedOn": "2025-01-28"},
+        "mentor-intro": {"status": "In Progress"},
+        "oasis-floor": {"status": "In Progress"},
+        "aml-training": {"status": "Not Started"}
+      }
+    },
+    {
+      "name": "Imogen Tao",
+      "staffId": "654321",
+      "role": "Sovereign Host",
+      "mentor": "Chantelle Hart",
+      "competencies": {
+        "welcome-day": {"status": "Complete", "completedOn": "2025-01-22"},
+        "mentor-intro": {"status": "Complete", "completedOn": "2025-01-25"},
+        "oasis-floor": {"status": "Complete", "completedOn": "2025-02-04"},
+        "sovereign-floor": {"status": "In Progress"},
+        "aml-training": {"status": "In Progress", "notes": "Awaiting LMS confirmation"}
+      }
+    },
+    {
+      "name": "Micah Latu",
+      "staffId": "882210",
+      "role": "Private Gaming Concierge",
+      "mentor": "Sasha Bloom",
+      "notes": "Prior experience at Treasury Brisbane.",
+      "competencies": {
+        "welcome-day": {"status": "Complete", "completedOn": "2025-01-08"},
+        "onboarding-pack": {"status": "Complete", "completedOn": "2025-01-05"},
+        "mentor-intro": {"status": "Complete", "completedOn": "2025-01-09"},
+        "sovereign-floor": {"status": "Complete", "completedOn": "2025-01-30"},
+        "bar-competency": {"status": "In Progress"},
+        "aml-training": {"status": "Complete", "completedOn": "2025-01-18"},
+        "host-standards": {"status": "In Progress"}
+      }
+    }
+  ]
+}

--- a/data/competency-template.json
+++ b/data/competency-template.json
@@ -1,0 +1,81 @@
+{
+  "title": "PGR Private Gaming Rooms Competency Checklist",
+  "version": "2025.1",
+  "statusOptions": ["Not Started", "In Progress", "Complete"],
+  "defaultStatus": "Not Started",
+  "metadataFields": [
+    {"key": "name", "label": "Team Member"},
+    {"key": "staffId", "label": "Staff ID"},
+    {"key": "role", "label": "Role"},
+    {"key": "mentor", "label": "Assigned Mentor"},
+    {"key": "startDateDisplay", "label": "Start Date"}
+  ],
+  "sections": [
+    {
+      "title": "Orientation & Foundations",
+      "description": "Baseline onboarding milestones for {{name}}.",
+      "items": [
+        {
+          "id": "welcome-day",
+          "label": "Attend Welcome Day",
+          "description": "Confirm attendance on {{startDateDisplay}} or next available session.",
+          "defaultStatus": "In Progress"
+        },
+        {
+          "id": "onboarding-pack",
+          "label": "Complete onboarding documentation",
+          "description": "All onboarding paperwork submitted before first rostered shift.",
+          "defaultStatus": "Not Started"
+        },
+        {
+          "id": "mentor-intro",
+          "label": "Meet assigned mentor {{mentor}}",
+          "description": "Schedule introductory session with mentor during Week 1.",
+          "defaultStatus": "Not Started"
+        }
+      ]
+    },
+    {
+      "title": "Outlet Competencies",
+      "description": "Capability milestones for Oasis and Sovereign outlets.",
+      "items": [
+        {
+          "id": "oasis-floor",
+          "label": "Complete Oasis floor immersion",
+          "description": "Shadow senior host to understand floor procedures and guest engagement standards.",
+          "defaultStatus": "Not Started"
+        },
+        {
+          "id": "sovereign-floor",
+          "label": "Demonstrate Sovereign floor readiness",
+          "description": "Complete 3 consecutive shifts achieving minimum guest satisfaction benchmarks.",
+          "defaultStatus": "Not Started"
+        },
+        {
+          "id": "bar-competency",
+          "label": "Complete bar service competency",
+          "description": "Demonstrate signature cocktails and table-side presentation standards.",
+          "defaultStatus": "Not Started"
+        }
+      ]
+    },
+    {
+      "title": "Compliance & Guest Care",
+      "description": "Regulatory and guest care requirements for {{department}} team members.",
+      "items": [
+        {
+          "id": "aml-training",
+          "label": "Anti-Money Laundering refresher",
+          "description": "Complete AML eLearning and knowledge check within first fortnight.",
+          "defaultStatus": "Not Started"
+        },
+        {
+          "id": "host-standards",
+          "label": "Private Gaming host service standards",
+          "description": "Demonstrate VIP service flow for two unique guest journeys.",
+          "defaultStatus": "Not Started"
+        }
+      ]
+    }
+  ]
+}

--- a/data/pgr_competency_checklist.json
+++ b/data/pgr_competency_checklist.json
@@ -1,0 +1,158 @@
+{
+  "bundle": "pgr_competency_checklist",
+  "template": {
+    "title": "PGR Private Gaming Rooms Competency Checklist",
+    "version": "2025.2",
+    "statusOptions": ["Not Started", "In Progress", "Complete", "Signed Off"],
+    "defaultStatus": "Not Started",
+    "metadataFields": [
+      {"key": "name", "label": "Team Member"},
+      {"key": "staffId", "label": "Staff ID"},
+      {"key": "role", "label": "Role"},
+      {"key": "department", "label": "Department"},
+      {"key": "mentor", "label": "Assigned Mentor"},
+      {"key": "startDateDisplay", "label": "Start Date"}
+    ],
+    "sections": [
+      {
+        "title": "Orientation & Foundations",
+        "description": "Baseline onboarding milestones for {{name}}.",
+        "items": [
+          {
+            "id": "welcome-day",
+            "label": "Attend Welcome Day",
+            "description": "Confirm attendance on {{startDateDisplay}} or next available session.",
+            "defaultStatus": "In Progress"
+          },
+          {
+            "id": "onboarding-pack",
+            "label": "Complete onboarding documentation",
+            "description": "All onboarding paperwork submitted before first rostered shift.",
+            "defaultStatus": "Not Started"
+          },
+          {
+            "id": "mentor-intro",
+            "label": "Meet assigned mentor {{mentor}}",
+            "description": "Schedule introductory session with mentor during Week 1.",
+            "defaultStatus": "Not Started"
+          }
+        ]
+      },
+      {
+        "title": "Venue Familiarisation",
+        "description": "Hands-on exposure across PGR venues.",
+        "items": [
+          {
+            "id": "oasis-floor",
+            "label": "Shadow Oasis host team",
+            "description": "Observe live service alongside {{mentor}}.",
+            "defaultStatus": "Not Started"
+          },
+          {
+            "id": "sovereign-floor",
+            "label": "Complete Sovereign Room immersion",
+            "description": "Full run-through of Sovereign guest journey.",
+            "defaultStatus": "Not Started"
+          },
+          {
+            "id": "bar-competency",
+            "label": "Demonstrate beverage service standards",
+            "description": "Execute Sovereign cocktail and beverage standards.",
+            "defaultStatus": "Not Started"
+          }
+        ]
+      },
+      {
+        "title": "Compliance & Host Excellence",
+        "description": "Critical compliance checkpoints for all Private Gaming talent.",
+        "items": [
+          {
+            "id": "aml-training",
+            "label": "Finish AML/CTF training in LMS",
+            "description": "Upload certificate to SuccessFactors upon completion.",
+            "defaultStatus": "Not Started"
+          },
+          {
+            "id": "host-standards",
+            "label": "Sign off on PGR host service standards",
+            "description": "Review service bible with {{mentor}} and Duty Manager.",
+            "defaultStatus": "Not Started"
+          },
+          {
+            "id": "handover-check",
+            "label": "Complete three supervised handovers",
+            "description": "Duty Manager to sign once confident in handover process.",
+            "defaultStatus": "Not Started"
+          }
+        ]
+      }
+    ]
+  },
+  "dataset": {
+    "templateVersion": "2025.2",
+    "updated": "2025-02-18",
+    "defaults": {
+      "role": "Private Gaming Host",
+      "department": "Private Gaming Rooms",
+      "mentor": "TBC",
+      "context": {
+        "brand": "PGR",
+        "handbookLink": "https://intranet.pgr.training/handbook"
+      },
+      "statusOptions": ["Not Started", "In Progress", "Complete", "Signed Off"],
+      "defaultStatus": "Not Started"
+    },
+    "people": [
+      {
+        "name": "Dakota Parata",
+        "staffId": "123456",
+        "role": "Private Gaming Host",
+        "mentor": "Jordan Rivers",
+        "notes": "Shadow Jordan for first Sovereign shift.",
+        "context": {
+          "orientationRoom": "Sovereign"
+        },
+        "competencies": {
+          "welcome-day": {"status": "Complete", "completedOn": "2025-02-03"},
+          "onboarding-pack": {"status": "Complete", "completedOn": "2025-01-28"},
+          "mentor-intro": {"status": "Signed Off", "completedOn": "2025-02-07"},
+          "oasis-floor": {"status": "In Progress"},
+          "aml-training": {"status": "In Progress", "notes": "Assessment booked 21 Feb"}
+        }
+      },
+      {
+        "name": "Imogen Tao",
+        "staffId": "654321",
+        "role": "Sovereign Host",
+        "mentor": "Chantelle Hart",
+        "competencies": {
+          "welcome-day": {"status": "Complete", "completedOn": "2025-01-22"},
+          "mentor-intro": {"status": "Complete", "completedOn": "2025-01-25"},
+          "oasis-floor": {"status": "Complete", "completedOn": "2025-02-04"},
+          "sovereign-floor": {"status": "In Progress"},
+          "aml-training": {"status": "In Progress", "notes": "Awaiting LMS confirmation"},
+          "handover-check": {"status": "Not Started"}
+        }
+      },
+      {
+        "name": "Micah Latu",
+        "staffId": "882210",
+        "role": "Private Gaming Concierge",
+        "mentor": "Sasha Bloom",
+        "notes": "Prior experience at Treasury Brisbane.",
+        "context": {
+          "orientationRoom": "Oasis"
+        },
+        "competencies": {
+          "welcome-day": {"status": "Complete", "completedOn": "2025-01-08"},
+          "onboarding-pack": {"status": "Complete", "completedOn": "2025-01-05"},
+          "mentor-intro": {"status": "Complete", "completedOn": "2025-01-09"},
+          "sovereign-floor": {"status": "Complete", "completedOn": "2025-01-30"},
+          "bar-competency": {"status": "In Progress"},
+          "aml-training": {"status": "Complete", "completedOn": "2025-01-18"},
+          "host-standards": {"status": "In Progress"}
+        }
+      }
+    ]
+  }
+}

--- a/index.html
+++ b/index.html
@@ -199,8 +199,38 @@
       </div>
     </section>
 
+    <section class="card" aria-labelledby="competency-h">
+      <div class="hd"><h2 id="competency-h">Step 3: Configure Competency Checklists</h2><span class="sub">Load a template, connect team member data, and preview exports</span></div>
+      <div class="bd">
+        <div class="grid g3">
+          <button id="loadDefaultCompetencies" class="btn" type="button">Use Default Template</button>
+          <button id="importTemplateBtn" class="btn" type="button">Import Template JSON</button>
+          <button id="importDatasetBtn" class="btn" type="button">Import Dataset JSON</button>
+          <input type="file" id="importTemplateInput" accept=".json" class="visually-hidden" />
+          <input type="file" id="importDatasetInput" accept=".json" class="visually-hidden" />
+        </div>
+        <div class="mt-4">
+          <div id="templateSummary" style="font-size:0.85rem; color:var(--text-secondary);">No competency template loaded.</div>
+          <div id="datasetSummary" style="font-size:0.85rem; color:var(--text-secondary); margin-top:0.5rem;">No competency dataset loaded.</div>
+        </div>
+        <div class="mt-4">
+          <label for="checklistPreviewSelect">Preview Checklist For</label>
+          <select id="checklistPreviewSelect"><option value="">Select a team member...</option></select>
+        </div>
+        <div id="checklistPreview" class="mt-4" style="border:1px solid var(--border-primary); border-radius:var(--radius-md); padding:1rem; background:var(--bg-tertiary); max-height:260px; overflow:auto; color:var(--text-secondary);">
+          Load a template and dataset to preview individualized checklists.
+        </div>
+        <div class="grid g2 mt-4">
+          <button id="exportChecklistCsv" class="btn" type="button">Export All Checklists (CSV)</button>
+          <button id="exportChecklistXls" class="btn" type="button">Export All Checklists (Excel)</button>
+          <button id="exportSelectedChecklistCsv" class="btn" type="button">Download Selected Checklist (CSV)</button>
+          <button id="printChecklistBtn" class="btn" type="button">Print Checklist</button>
+        </div>
+      </div>
+    </section>
+
     <section class="card" aria-labelledby="mandatory-h">
-      <div class="hd"><h2 id="mandatory-h">Step 3: Session Days</h2><span class="sub">Choose days for mandatory sessions</span></div>
+      <div class="hd"><h2 id="mandatory-h">Step 4: Session Days</h2><span class="sub">Choose days for mandatory sessions</span></div>
       <div class="bd">
         <div class="grid g2">
           <div><label for="welcomeDaySel">Welcome Day</label><select id="welcomeDaySel"><option value="1">Monday</option><option value="2" selected>Tuesday</option><option value="3">Wednesday</option><option value="4">Thursday</option><option value="5">Friday</option><option value="6">Saturday</option></select></div>
@@ -210,7 +240,7 @@
     </section>
 
     <section class="card" aria-labelledby="schedule-h">
-      <div class="hd"><h2 id="schedule-h">Step 4: Generated Roster</h2><span class="sub">Click "Build Roster" to see the results here</span></div>
+      <div class="hd"><h2 id="schedule-h">Step 5: Generated Roster</h2><span class="sub">Click "Build Roster" to see the results here</span></div>
       <div class="bd" style="padding: 0;">
         <div class="table-wrapper">
           <table id="schedTbl">
@@ -256,9 +286,411 @@ window.onload = () => {
     };
     const AVATARS = ['🦊', '🐼', '🦉', '🦁', '🐙', '🐳', '🦄', '🐲', '🌟', '🚀', '🎲', '🎯'];
     const AVATAR_TOOLTIP = 'This avatar is just for fun and has no effect on scheduling.';
+    const DEFAULT_COMPETENCY_BUNDLE_URL = 'data/pgr_competency_checklist.json';
+    const DEFAULT_COMPETENCY_BUNDLE_LABEL = 'pgr_competency_checklist.json';
+    const LEGACY_COMPETENCY_TEMPLATE_URL = 'data/competency-template.json';
+    const LEGACY_COMPETENCY_DATASET_URL = 'data/competency-dataset.json';
+
+    let competencyTemplate = null;
+    let competencyDataset = null;
+    let competencySource = { template: '', dataset: '' };
+    let checklistMap = new Map();
+    let selectedChecklistKey = '';
 
     function getRandomAvatar() { return AVATARS[Math.floor(Math.random() * AVATARS.length)]; }
     function getAvatarMarkup(avatar) { return avatar ? `<span class="starter-avatar" title="${AVATAR_TOOLTIP}">${avatar}</span>` : ''; }
+
+    // --- COMPETENCY CHECKLIST HELPERS ---
+    const competencyTools = {};
+
+    function getStarterKey(starter) {
+        if (!starter) return '';
+        const id = (starter.StaffID || '').trim();
+        return id ? `id:${id.toLowerCase()}` : `name:${starter.Name.toLowerCase()}`;
+    }
+
+    function findDatasetEntry(starter) {
+        if (!competencyDataset?.people) return null;
+        const staffId = (starter.StaffID || '').trim().toLowerCase();
+        if (staffId) {
+            const byId = competencyDataset.people.find(p => (p.staffId || '').trim().toLowerCase() === staffId);
+            if (byId) return byId;
+        }
+        return competencyDataset.people.find(p => (p.name || '').trim().toLowerCase() === starter.Name.trim().toLowerCase()) || null;
+    }
+
+    function applyPlaceholders(text, context) {
+        if (!text) return '';
+        return text.replace(/\{\{\s*([^}]+?)\s*\}\}/g, (_, key) => {
+            const value = context[key.trim()];
+            return value == null ? '' : String(value);
+        });
+    }
+
+    function mapTemplateToStarter(template, starter, datasetEntry = {}, defaults = {}) {
+        if (!template || !starter) return null;
+        const isoStart = starter.StartDate || '';
+        const startDateObj = isoStart ? parseYMD(isoStart) : null;
+        const context = {
+            name: starter.Name,
+            staffId: starter.StaffID || '',
+            startDate: isoStart,
+            startDateDisplay: startDateObj ? toDMY(startDateObj) : '',
+            role: datasetEntry.role || defaults.role || '',
+            mentor: datasetEntry.mentor || defaults.mentor || '',
+            department: datasetEntry.department || defaults.department || '',
+            ...datasetEntry.context,
+            ...defaults.context
+        };
+        const metadata = (template.metadataFields || []).map(field => ({
+            key: field.key,
+            label: field.label,
+            value: datasetEntry[field.key] ?? defaults[field.key] ?? context[field.key] ?? ''
+        }));
+        const statusOptions = template.statusOptions || defaults.statusOptions || ['Not Started', 'In Progress', 'Complete'];
+        const defaultStatus = template.defaultStatus || defaults.defaultStatus || statusOptions[0];
+        const sections = (template.sections || []).map(section => {
+            const items = (section.items || []).map(item => {
+                const entry = datasetEntry?.competencies?.[item.id] || {};
+                const itemStatus = entry.status || item.defaultStatus || defaultStatus;
+                return {
+                    id: item.id,
+                    label: applyPlaceholders(item.label, context),
+                    description: applyPlaceholders(item.description || '', context),
+                    status: itemStatus,
+                    statusOptions: item.statusOptions || statusOptions,
+                    completedOn: entry.completedOn || item.completedOn || '',
+                    notes: entry.notes || datasetEntry.notes || '',
+                    evidence: entry.evidence || ''
+                };
+            });
+            return {
+                title: applyPlaceholders(section.title || '', context),
+                description: applyPlaceholders(section.description || '', context),
+                items
+            };
+        });
+        return {
+            title: template.title || 'Competency Checklist',
+            version: template.version || '1.0',
+            generatedOn: new Date().toISOString(),
+            name: starter.Name,
+            staffId: starter.StaffID || '',
+            startDate: isoStart,
+            metadata,
+            sections
+        };
+    }
+
+    function flattenChecklist(checklist) {
+        if (!checklist) return [];
+        const rows = [];
+        for (const section of checklist.sections || []) {
+            for (const item of section.items || []) {
+                rows.push({
+                    Name: checklist.name,
+                    StaffID: checklist.staffId || '',
+                    Section: section.title || '',
+                    Item: item.label || '',
+                    Status: item.status || '',
+                    CompletedOn: item.completedOn || '',
+                    Notes: item.notes || '',
+                    Evidence: item.evidence || ''
+                });
+            }
+        }
+        return rows;
+    }
+
+    function flattenChecklistCollection(checklists) {
+        const rows = [];
+        for (const cl of checklists.values()) {
+            rows.push(...flattenChecklist(cl));
+        }
+        return rows;
+    }
+
+    competencyTools.mapTemplateToStarter = mapTemplateToStarter;
+    competencyTools.flattenChecklist = flattenChecklist;
+    competencyTools.flattenChecklistCollection = flattenChecklistCollection;
+    window.__competencyTools = competencyTools;
+
+    function describeTemplate(template) {
+        if (!template) return 'No competency template loaded.';
+        const sectionCount = (template.sections || []).length;
+        return `${template.title || 'Template'} (v${template.version || '1.0'}) • ${sectionCount} section${sectionCount === 1 ? '' : 's'}`;
+    }
+
+    function describeDataset(dataset) {
+        if (!dataset) return 'No competency dataset loaded.';
+        const personCount = (dataset.people || []).length;
+        const version = dataset.templateVersion ? `v${dataset.templateVersion}` : 'unversioned';
+        return `Dataset ${version} • ${personCount} record${personCount === 1 ? '' : 's'}`;
+    }
+
+    function csvEscape(value) {
+        if (value == null) return '';
+        const str = String(value).replace(/"/g, '""');
+        return /[",\n]/.test(str) ? `"${str}"` : str;
+    }
+
+    function buildChecklistHtml(checklist, { compact = false } = {}) {
+        if (!checklist) return '<p>No checklist available.</p>';
+        const metaHtml = (checklist.metadata || []).map(m => `<div style="margin-bottom:0.25rem;"><strong>${m.label}:</strong> ${m.value || '—'}</div>`).join('');
+        const sectionHtml = (checklist.sections || []).map(section => {
+            const items = (section.items || []).map(item => {
+                return `<li style="margin-bottom:0.35rem;"><div><strong>${item.label}</strong> <span style="color:var(--brand-secondary, #D4AF37);">${item.status || '—'}</span></div>${item.description ? `<div style="font-size:0.75rem; color:var(--text-muted, #737373);">${item.description}</div>` : ''}${item.completedOn ? `<div style="font-size:0.75rem; color:var(--text-muted, #737373);">Completed: ${item.completedOn}</div>` : ''}${item.notes ? `<div style="font-size:0.75rem; color:var(--text-muted, #737373);">Notes: ${item.notes}</div>` : ''}</li>`;
+            }).join('');
+            return `<section style="margin-top:1rem;"><h4 style="margin:0 0 0.5rem; font-size:${compact ? '0.85rem' : '1rem'}; color:var(--text-primary, #f5f5f5);">${section.title}</h4>${section.description ? `<p style="margin:0 0 0.5rem; font-size:0.8rem; color:var(--text-secondary, #a3a3a3);">${section.description}</p>` : ''}<ul style="padding-left:1rem; margin:0; list-style:disc;">${items || '<li>No items configured.</li>'}</ul></section>`;
+        }).join('');
+        return `<article style="background:var(--surface, #1f1f1f); border:1px solid var(--border-primary, #404040); border-radius:var(--radius-md, 12px); padding:${compact ? '0.75rem' : '1rem'}; margin-bottom:1rem;"><header style="margin-bottom:0.75rem;"><h3 style="margin:0; color:var(--brand-secondary, #D4AF37); font-size:${compact ? '1rem' : '1.15rem'};">${checklist.name}</h3><div style="font-size:0.8rem; color:var(--text-muted, #737373);">Staff ID: ${checklist.staffId || 'N/A'} • Start: ${checklist.startDate ? toDMY(parseYMD(checklist.startDate)) : 'TBC'} • Template v${checklist.version}</div></header><div style="font-size:0.8rem; color:var(--text-secondary, #a3a3a3);">${metaHtml || '<em>No additional metadata</em>'}</div>${sectionHtml}</article>`;
+    }
+
+    function updateChecklistSummaries() {
+        const templateSummary = byId('templateSummary');
+        const datasetSummary = byId('datasetSummary');
+        if (templateSummary) templateSummary.textContent = competencyTemplate ? `${describeTemplate(competencyTemplate)}${competencySource.template ? ` • ${competencySource.template}` : ''}` : 'No competency template loaded.';
+        if (datasetSummary) datasetSummary.textContent = competencyDataset ? `${describeDataset(competencyDataset)}${competencySource.dataset ? ` • ${competencySource.dataset}` : ''}` : 'No competency dataset loaded.';
+    }
+
+    function updateChecklistSelect() {
+        const select = byId('checklistPreviewSelect');
+        if (!select) return;
+        const previousValue = selectedChecklistKey;
+        select.innerHTML = '<option value="">Select a team member...</option>';
+        for (const starter of starters) {
+            const key = getStarterKey(starter);
+            const option = document.createElement('option');
+            option.value = key;
+            option.textContent = starter.StaffID ? `${starter.Name} • ${starter.StaffID}` : starter.Name;
+            if (!checklistMap.has(key)) option.disabled = !competencyTemplate;
+            select.appendChild(option);
+        }
+        if (previousValue && checklistMap.has(previousValue)) {
+            select.value = previousValue;
+        } else {
+            select.value = '';
+        }
+    }
+
+    function renderChecklistPreview(checklist) {
+        const preview = byId('checklistPreview');
+        if (!preview) return;
+        if (!competencyTemplate) {
+            preview.innerHTML = 'Load a template and dataset to preview individualized checklists.';
+            return;
+        }
+        if (!checklist) {
+            preview.innerHTML = starters.length ? 'Select a team member to preview their checklist.' : 'Add team members to generate personalized checklists.';
+            return;
+        }
+        preview.innerHTML = buildChecklistHtml(checklist, { compact: true });
+    }
+
+    function syncChecklists() {
+        checklistMap = new Map();
+        if (!competencyTemplate) {
+            updateChecklistSelect();
+            renderChecklistPreview(null);
+            return;
+        }
+        const defaults = competencyDataset?.defaults || {};
+        for (const starter of starters) {
+            const entry = findDatasetEntry(starter) || {};
+            const key = getStarterKey(starter);
+            const checklist = mapTemplateToStarter(competencyTemplate, starter, entry, defaults);
+            checklistMap.set(key, checklist);
+        }
+        updateChecklistSelect();
+        if (selectedChecklistKey && !checklistMap.has(selectedChecklistKey)) selectedChecklistKey = '';
+        if (!selectedChecklistKey && starters.length) {
+            const firstKey = getStarterKey(starters[0]);
+            if (checklistMap.has(firstKey)) selectedChecklistKey = firstKey;
+        }
+        const select = byId('checklistPreviewSelect');
+        if (select) select.value = selectedChecklistKey || '';
+        renderChecklistPreview(selectedChecklistKey ? checklistMap.get(selectedChecklistKey) : null);
+    }
+
+    function exportAllChecklistsCsv() {
+        if (!checklistMap.size) { showModal('Export Error', 'Load a template and add starters before exporting.'); return; }
+        const rows = flattenChecklistCollection(checklistMap);
+        if (!rows.length) { showModal('Export Error', 'No checklist rows available to export.'); return; }
+        const header = ['Name', 'StaffID', 'Section', 'Item', 'Status', 'CompletedOn', 'Notes', 'Evidence'];
+        const csv = [header.join(',')].concat(rows.map(row => header.map(col => csvEscape(row[col])).join(','))).join('\n');
+        download('competency-checklists.csv', csv);
+    }
+
+    function exportSelectedChecklistCsv() {
+        if (!selectedChecklistKey || !checklistMap.has(selectedChecklistKey)) {
+            showModal('Export Error', 'Select a team member to export their checklist.');
+            return;
+        }
+        const checklist = checklistMap.get(selectedChecklistKey);
+        const rows = flattenChecklist(checklist);
+        if (!rows.length) { showModal('Export Error', 'The selected checklist has no items to export.'); return; }
+        const header = ['Name', 'StaffID', 'Section', 'Item', 'Status', 'CompletedOn', 'Notes', 'Evidence'];
+        const csv = [header.join(',')].concat(rows.map(row => header.map(col => csvEscape(row[col])).join(','))).join('\n');
+        download(`${checklist.name.replace(/[^a-z0-9]+/gi, '_').toLowerCase()}_competency.csv`, csv);
+    }
+
+    function exportAllChecklistsXls() {
+        if (!checklistMap.size) { showModal('Export Error', 'Load a template and add starters before exporting.'); return; }
+        const wb = XLSX.utils.book_new();
+        const allRows = flattenChecklistCollection(checklistMap);
+        if (allRows.length) {
+            const wsAll = XLSX.utils.json_to_sheet(allRows);
+            XLSX.utils.book_append_sheet(wb, wsAll, 'All Checklists');
+        }
+        for (const checklist of checklistMap.values()) {
+            const rows = flattenChecklist(checklist);
+            const metaRows = [['Team Member', checklist.name], ['Staff ID', checklist.staffId || ''], ['Template Version', checklist.version], ['Generated On', checklist.generatedOn]];
+            for (const meta of checklist.metadata || []) {
+                metaRows.push([meta.label, meta.value || '']);
+            }
+            metaRows.push([]);
+            metaRows.push(['Section', 'Item', 'Status', 'Completed On', 'Notes', 'Evidence']);
+            for (const row of rows) {
+                metaRows.push([row.Section, row.Item, row.Status, row.CompletedOn, row.Notes, row.Evidence]);
+            }
+            const ws = XLSX.utils.aoa_to_sheet(metaRows);
+            let sheetName = checklist.name || 'Checklist';
+            if (sheetName.length > 28) sheetName = sheetName.slice(0, 28);
+            XLSX.utils.book_append_sheet(wb, ws, sheetName);
+        }
+        XLSX.writeFile(wb, 'competency-checklists.xlsx');
+    }
+
+    function printChecklists() {
+        if (!checklistMap.size) { showModal('Print Error', 'Load a template and add starters before printing.'); return; }
+        const targets = selectedChecklistKey && checklistMap.has(selectedChecklistKey) ? [checklistMap.get(selectedChecklistKey)] : Array.from(checklistMap.values());
+        const html = `<!doctype html><html><head><meta charset="utf-8"><title>Competency Checklists</title><style>body{font-family:${getComputedStyle(document.body).fontFamily};background:#fff;color:#111;padding:32px;}h1{margin-top:0;}article{page-break-inside:avoid;box-shadow:none;border:1px solid #ccc;padding:16px;margin-bottom:24px;border-radius:8px;}section{margin-top:16px;}ul{padding-left:18px;}li{margin-bottom:8px;font-size:14px;}header{margin-bottom:12px;}@media print{body{padding:0;}article{border:none;}}</style></head><body><h1>Competency Checklists</h1>${targets.map(cl => buildChecklistHtml(cl, { compact: false })).join('<hr>')}</body></html>`;
+        const win = window.open('', '_blank');
+        if (!win) { showModal('Print Error', 'Pop-up blocked. Please enable pop-ups to print.'); return; }
+        win.document.write(html);
+        win.document.close();
+        win.focus();
+        win.print();
+    }
+
+    async function fetchText(url) {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`Failed to load ${url}: ${res.status}`);
+        return res.text();
+    }
+
+    async function fetchJson(url) {
+        const text = await fetchText(url);
+        try {
+            return JSON.parse(text);
+        } catch (error) {
+            throw new Error(`Failed to parse JSON from ${url}: ${error.message || error}`);
+        }
+    }
+
+    async function fetchCompetencyBundle(url) {
+        const bundle = await fetchJson(url);
+        if (!bundle || typeof bundle !== 'object') {
+            throw new Error('Bundle response was empty');
+        }
+        if (!bundle.template || !bundle.dataset) {
+            throw new Error('Bundle missing template or dataset fields');
+        }
+        return bundle;
+    }
+
+    function setCompetencyTemplate(template, sourceLabel = '') {
+        competencyTemplate = template;
+        competencySource.template = sourceLabel;
+        updateChecklistSummaries();
+    }
+
+    function setCompetencyDataset(dataset, sourceLabel = '') {
+        competencyDataset = dataset;
+        competencySource.dataset = sourceLabel;
+        updateChecklistSummaries();
+    }
+
+    async function loadDefaultCompetencies() {
+        let bundleError = null;
+        try {
+            const bundle = await fetchCompetencyBundle(DEFAULT_COMPETENCY_BUNDLE_URL);
+            const dataset = bundle.dataset;
+            const bundleLabel = bundle.bundle || DEFAULT_COMPETENCY_BUNDLE_LABEL;
+            setCompetencyTemplate(bundle.template, `Default bundle (${bundleLabel})`);
+            const datasetLabel = dataset.templateVersion
+                ? `${bundleLabel} (v${dataset.templateVersion})`
+                : bundleLabel;
+            setCompetencyDataset(dataset, datasetLabel);
+            syncChecklists();
+            return;
+        } catch (error) {
+            bundleError = error;
+            console.warn('Default competency bundle failed, attempting legacy assets:', error);
+        }
+
+        try {
+            const [template, dataset] = await Promise.all([
+                fetchJson(LEGACY_COMPETENCY_TEMPLATE_URL),
+                fetchJson(LEGACY_COMPETENCY_DATASET_URL)
+            ]);
+            setCompetencyTemplate(template, 'Legacy default bundle');
+            setCompetencyDataset(dataset, dataset.templateVersion ? `Legacy bundle (${dataset.templateVersion})` : 'Legacy bundle');
+            syncChecklists();
+        } catch (error) {
+            console.error('Default competency load failed:', error);
+            const reason = bundleError ? `Bundle: ${bundleError.message || bundleError}.` : '';
+            showModal('Load Error', `Unable to load the default competency assets.${reason ? ` ${reason}` : ''} Please try importing them manually.`);
+        }
+    }
+
+    function readJsonFile(file) {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => {
+                try {
+                    resolve(JSON.parse(reader.result));
+                } catch (error) {
+                    reject(error);
+                }
+            };
+            reader.onerror = () => reject(reader.error || new Error('Unable to read file.'));
+            reader.readAsText(file);
+        });
+    }
+
+    async function handleTemplateImport(event) {
+        const file = event.target.files?.[0];
+        event.target.value = '';
+        if (!file) return;
+        try {
+            const template = await readJsonFile(file);
+            setCompetencyTemplate(template, `Imported (${file.name})`);
+            syncChecklists();
+        } catch (error) {
+            console.error('Template import failed:', error);
+            showModal('Template Error', 'The selected template file is not valid JSON.');
+        }
+    }
+
+    async function handleDatasetImport(event) {
+        const file = event.target.files?.[0];
+        event.target.value = '';
+        if (!file) return;
+        try {
+            const dataset = await readJsonFile(file);
+            setCompetencyDataset(dataset, `Imported (${file.name})`);
+            syncChecklists();
+        } catch (error) {
+            console.error('Dataset import failed:', error);
+            showModal('Dataset Error', 'The selected dataset file is not valid JSON.');
+        }
+    }
+
+    function handleChecklistSelectionChange(event) {
+        selectedChecklistKey = event.target.value || '';
+        renderChecklistPreview(selectedChecklistKey ? checklistMap.get(selectedChecklistKey) : null);
+    }
 
     // --- HELPER FUNCTIONS ---
     const byId = id => document.getElementById(id);
@@ -400,7 +832,11 @@ window.onload = () => {
     // --- STARTER MANAGEMENT ---
     function renderStarters() {
         const tb = document.querySelector('#startersTbl tbody');
-        if (starters.length === 0) { tb.innerHTML = `<tr><td colspan="6" style="text-align:center; color: var(--text-muted); padding: 2rem;">No starters added yet.</td></tr>`; return; }
+        if (starters.length === 0) {
+            tb.innerHTML = `<tr><td colspan="6" style="text-align:center; color: var(--text-muted); padding: 2rem;">No starters added yet.</td></tr>`;
+            syncChecklists();
+            return;
+        }
         tb.innerHTML = starters.map((s, i) => {
             if (!s.Avatar) s.Avatar = getRandomAvatar();
             const avatar = getAvatarMarkup(s.Avatar);
@@ -414,6 +850,7 @@ window.onload = () => {
             renderCalendar();
             openCalendarModal();
         });
+        syncChecklists();
     }
     function openStartDatePicker(e) {
         if (e) { e.preventDefault(); }
@@ -580,6 +1017,16 @@ window.onload = () => {
     byId('importStartersBtn').onclick = () => byId('importStarters').click();
     byId('importStarters').onchange = importStarters;
     byId('exportStartersBtn').onclick = exportStarters;
+    byId('loadDefaultCompetencies').onclick = loadDefaultCompetencies;
+    byId('importTemplateBtn').onclick = () => byId('importTemplateInput').click();
+    byId('importDatasetBtn').onclick = () => byId('importDatasetInput').click();
+    byId('importTemplateInput').onchange = handleTemplateImport;
+    byId('importDatasetInput').onchange = handleDatasetImport;
+    byId('checklistPreviewSelect').addEventListener('change', handleChecklistSelectionChange);
+    byId('exportChecklistCsv').onclick = exportAllChecklistsCsv;
+    byId('exportChecklistXls').onclick = exportAllChecklistsXls;
+    byId('exportSelectedChecklistCsv').onclick = exportSelectedChecklistCsv;
+    byId('printChecklistBtn').onclick = printChecklists;
     byId('shuffleBlocks').onclick = () => {
         shuffle = !shuffle;
         const btn = byId('shuffleBlocks');
@@ -592,6 +1039,8 @@ window.onload = () => {
     byId('exportAllXls').onclick = () => { if (!allRows.length) { showModal('Export Error', 'Build a schedule first.'); return; } const wsSchedule = XLSX.utils.json_to_sheet(allRows.map(r => ({ Starter: r.Starter, StaffID: r.StaffID || '', Date: toDMY(parseYMD(r.Date)), Start: r.Start, End: r.End, Outlet: r.Outlet, Step: r.Step, Shift: r.Shift }))); const wsStarters = XLSX.utils.json_to_sheet(starters.map(s => ({ Name: s.Name, StaffID: s.StaffID || '', StartDate: s.StartDate }))); const wb = XLSX.utils.book_new(); XLSX.utils.book_append_sheet(wb, wsSchedule, "Roster"); XLSX.utils.book_append_sheet(wb, wsStarters, "Starters"); XLSX.writeFile(wb, "roster_and_starters.xlsx"); };
 
     // --- INITIAL SETUP ---
+    updateChecklistSummaries();
+    loadDefaultCompetencies();
     renderStarters();
     renderSched([]);
 };

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,12 +1,13 @@
 const test = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const vm = require('node:vm');
 
 test('smoke test', () => {
   assert.strictEqual(1, 1);
 });
 
 test('start times are no later than 20:00', () => {
-  const fs = require('node:fs');
   const html = fs.readFileSync('index.html', 'utf8');
   const match = html.match(/const RULES = {[\s\S]*?};/);
   assert.ok(match, 'RULES constant not found');
@@ -18,8 +19,6 @@ test('start times are no later than 20:00', () => {
 });
 
 test('pickTime enforces 20:00 limit and provides safe fallbacks', () => {
-  const fs = require('node:fs');
-  const vm = require('node:vm');
   const html = fs.readFileSync('index.html', 'utf8');
 
   const rulesMatch = html.match(/const RULES = {[\s\S]*?};/);
@@ -48,4 +47,64 @@ test('pickTime enforces 20:00 limit and provides safe fallbacks', () => {
 
   RULES.AllLate = ['22:30'];
   assert.strictEqual(pickTime('AllLate', 0), '20:00');
+});
+
+test('competency template maps to starters and exports rows', () => {
+  const bundle = JSON.parse(fs.readFileSync('data/pgr_competency_checklist.json', 'utf8'));
+  assert.ok(bundle.template, 'bundle template missing');
+  assert.ok(bundle.dataset, 'bundle dataset missing');
+  const template = bundle.template;
+  const dataset = bundle.dataset;
+  const html = fs.readFileSync('index.html', 'utf8');
+  const blockMatch = html.match(/const competencyTools = {};[\s\S]*?window.__competencyTools = competencyTools;/);
+  assert.ok(blockMatch, 'competency helper block not found');
+
+  const sandbox = { window: {}, console };
+  vm.createContext(sandbox);
+  const helperPrelude = `
+    const pad2 = n => (n < 10 ? '0' : '') + n;
+    const parseYMD = s => { const [y, m, d] = s.split('-').map(Number); return new Date(y, m - 1, d); };
+    const toDMY = d => pad2(d.getDate()) + '/' + pad2(d.getMonth() + 1) + '/' + d.getFullYear();
+  `;
+  vm.runInContext(helperPrelude + blockMatch[0], sandbox);
+  const tools = sandbox.window.__competencyTools;
+  assert.ok(tools, 'competency tools were not exposed');
+  assert.strictEqual(typeof tools.mapTemplateToStarter, 'function');
+  assert.strictEqual(typeof tools.flattenChecklistCollection, 'function');
+
+  const starters = [
+    { Name: 'Dakota Parata', StaffID: '123456', StartDate: '2025-02-03' },
+    { Name: 'Jordan Test', StaffID: '999999', StartDate: '2025-03-01' }
+  ];
+
+  const checklistMap = new Map();
+  for (const starter of starters) {
+    const entry = dataset.people.find(p => (p.staffId || '').toLowerCase() === starter.StaffID.toLowerCase()) || {};
+    const checklist = tools.mapTemplateToStarter(template, starter, entry, dataset.defaults || {});
+    assert.ok(checklist, 'checklist not generated');
+    assert.strictEqual(checklist.sections.length, template.sections.length, 'section count mismatch');
+    checklistMap.set(starter.StaffID, checklist);
+  }
+
+  const dakotaChecklist = checklistMap.get('123456');
+  const mentorItem = dakotaChecklist.sections
+    .flatMap(section => section.items)
+    .find(item => item.id === 'mentor-intro');
+  assert.ok(mentorItem, 'mentor item missing');
+  assert.ok(/Jordan Rivers/.test(mentorItem.label), 'mentor placeholder not resolved');
+  assert.strictEqual(mentorItem.status, 'Signed Off', 'mentor status should reflect Signed Off option');
+  const welcomeItem = dakotaChecklist.sections[0].items.find(item => item.id === 'welcome-day');
+  assert.strictEqual(welcomeItem.status, 'Complete');
+
+  const fallbackChecklist = checklistMap.get('999999');
+  const fallbackStatus = fallbackChecklist.sections[0].items[1].status;
+  assert.strictEqual(fallbackStatus, template.sections[0].items[1].defaultStatus || template.defaultStatus, 'default status not applied');
+
+  const rows = tools.flattenChecklistCollection(checklistMap);
+  const expectedRowCount = starters.length * template.sections.reduce((sum, section) => sum + (section.items || []).length, 0);
+  assert.strictEqual(rows.length, expectedRowCount, 'flattenChecklistCollection produced unexpected row count');
+
+  const dakotaRow = rows.find(row => row.Name === 'Dakota Parata' && row.Item.includes('Attend Welcome Day'));
+  assert.ok(dakotaRow, 'expected Dakota row missing');
+  assert.strictEqual(dakotaRow.Status, 'Complete');
 });


### PR DESCRIPTION
## Summary
- replace the old text-based competency bundle with the new `pgr_competency_checklist.json` asset that includes updated template metadata and dataset records
- point the app loader and documentation at the JSON bundle while keeping the legacy template/dataset fallbacks intact
- extend the competency test coverage to validate the new "Signed Off" status and ensure the JSON bundle parses correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8dd6566f4832abf3fcb2e30d22fc1