### PR TITLE
Add Express backend for roster generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ data/*.xlsx
 # Python cache
 __pycache__/
 .env
+
+# Node dependencies
+node_modules/

--- a/backend/rosterEngine.js
+++ b/backend/rosterEngine.js
@@ -1,0 +1,423 @@
+'use strict';
+
+const DEFAULT_MIN_SHIFTS = 15;
+const MANDATORY_SESSIONS = [
+  { name: 'Welcome Day', label: 'Welcome Day', start: '09:00' },
+  { name: 'PGR F&B On boarding', label: 'PGR F&B On boarding', start: '09:00' }
+];
+const RULES = {
+  'Oasis Food': ['08:00', '11:00', '16:00'],
+  'Oasis Bar': ['06:00', '08:00', '10:00', '14:00', '16:00', '17:00', '18:00', '19:00'],
+  'SOV South Floor': Array.from({ length: 12 }, (_, k) => `${(9 + k).toString().padStart(2, '0')}:00`),
+  'SOV North Floor': ['18:00'],
+  'SOV South Bar': ['06:00', '10:00', '14:00', '18:00'],
+  'SOV Dining': ['17:00']
+};
+const DEFAULT_BLOCKS = {
+  'Oasis Food': 3,
+  'Oasis Bar': 2,
+  'SOV South Floor': 3,
+  'SOV North Floor': 1,
+  'SOV South Bar': 1,
+  'SOV Dining': 4
+};
+const MINIMUM_BLOCKS = {
+  'SOV South Floor': 3
+};
+
+function parseYMD(iso) {
+  if (typeof iso !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(iso)) {
+    throw new Error(`Invalid ISO date string: ${iso}`);
+  }
+  const [year, month, day] = iso.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function toYMD(date) {
+  const pad = (n) => (n < 10 ? `0${n}` : `${n}`);
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+function nextDow(startDate, dow, includeStart = true) {
+  const d = new Date(startDate);
+  if (!includeStart) d.setDate(d.getDate() + 1);
+  while (d.getDay() !== dow) d.setDate(d.getDate() + 1);
+  return d;
+}
+
+function isSun(date) {
+  return date.getDay() === 0;
+}
+
+function isMon(date) {
+  return date.getDay() === 1;
+}
+
+function nextWorking(date) {
+  const d = new Date(date);
+  while (isSun(d) || isMon(d)) {
+    d.setDate(d.getDate() + 1);
+  }
+  return d;
+}
+
+function addWorkDay(date) {
+  const d = new Date(date);
+  d.setDate(d.getDate() + 1);
+  return nextWorking(d);
+}
+
+function isOutletAllowedOnDate(outlet, dateObj) {
+  const dow = dateObj.getDay();
+  if (dow === 0) return false;
+  if (outlet === 'SOV North Floor') return dow === 5 || dow === 6;
+  return true;
+}
+
+function pickTime(outlet, index) {
+  const times = (RULES[outlet] || ['09:00']).filter((time) => time <= '20:00');
+  const safe = times.length ? times : ['20:00'];
+  return safe[index % safe.length];
+}
+
+function pad2(value) {
+  return value < 10 ? `0${value}` : `${value}`;
+}
+
+function makeRow(starter, dateObj, start, outlet, step) {
+  const [hh, mm] = start.split(':').map(Number);
+  const endH = (hh + 5) % 24;
+  const endM = mm;
+  return {
+    Starter: starter.Name,
+    StaffID: starter.StaffID || '',
+    Avatar: starter.Avatar || '',
+    Date: toYMD(dateObj),
+    Start: start,
+    End: `${pad2(endH)}:${pad2(endM)}`,
+    Outlet: outlet,
+    Step: step,
+    Shift: `${start.replace(':', '')}-${pad2(endH)}${pad2(endM)} ${outlet} TRN`
+  };
+}
+
+function sanitizeBlocks(blocks = []) {
+  const normalized = { ...DEFAULT_BLOCKS };
+  if (Array.isArray(blocks)) {
+    for (const block of blocks) {
+      if (!block || typeof block !== 'object') continue;
+      const outlet = block.outlet || block.name;
+      if (!outlet) continue;
+      const raw = Number(block.count ?? block.shifts ?? block.value);
+      if (Number.isNaN(raw)) continue;
+      const minimum = MINIMUM_BLOCKS[outlet] || 0;
+      normalized[outlet] = Math.max(minimum, Math.max(0, Math.floor(raw)));
+    }
+  } else if (blocks && typeof blocks === 'object') {
+    for (const [outlet, value] of Object.entries(blocks)) {
+      const minimum = MINIMUM_BLOCKS[outlet] || 0;
+      const raw = Number(value);
+      if (!Number.isNaN(raw)) {
+        normalized[outlet] = Math.max(minimum, Math.max(0, Math.floor(raw)));
+      }
+    }
+  }
+  return normalized;
+}
+
+function sanitizeStarters(starters) {
+  if (!Array.isArray(starters) || starters.length === 0) {
+    throw new Error('At least one starter is required to build a roster.');
+  }
+  return starters.map((s, index) => {
+    if (!s || typeof s !== 'object') {
+      throw new Error(`Starter at index ${index} must be an object.`);
+    }
+    const Name = (s.Name || s.name || '').trim();
+    if (!Name) {
+      throw new Error(`Starter at index ${index} is missing a name.`);
+    }
+    const startDate = s.StartDate || s.startDate;
+    if (!startDate) {
+      throw new Error(`Starter "${Name}" is missing StartDate.`);
+    }
+    parseYMD(startDate);
+    const blackout = Array.isArray(s.blackoutDates) ? s.blackoutDates.filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d)) : [];
+    return {
+      Name,
+      StaffID: (s.StaffID || s.staffId || '').trim(),
+      StartDate: startDate,
+      blackoutDates: blackout,
+      Avatar: s.Avatar || s.avatar || ''
+    };
+  });
+}
+
+function shiftsInLastNDays(rows, starterName, dateObj, n) {
+  const start = new Date(dateObj);
+  start.setDate(start.getDate() - (n - 1));
+  const startKey = toYMD(start);
+  const endKey = toYMD(dateObj);
+  let count = 0;
+  for (const row of rows) {
+    if (row.Starter !== starterName) continue;
+    if (row.Outlet === MANDATORY_SESSIONS[0].label || row.Outlet === MANDATORY_SESSIONS[1].label) continue;
+    if (row.Date >= startKey && row.Date <= endKey) count++;
+  }
+  return count;
+}
+
+function canWorkThisDay(rows, starterName, dateObj) {
+  return shiftsInLastNDays(rows, starterName, dateObj, 10) < 8;
+}
+
+function lastShiftEnd(rows, starterName) {
+  let last = null;
+  for (const row of rows) {
+    if (row.Starter !== starterName) continue;
+    const date = parseYMD(row.Date);
+    const [hh, mm] = row.End.split(':').map(Number);
+    date.setHours(hh, mm, 0, 0);
+    if (!last || date > last) last = date;
+  }
+  return last;
+}
+
+function hasMinRest(rows, starterName, dateObj, startTime) {
+  const last = lastShiftEnd(rows, starterName);
+  if (!last) return true;
+  const start = new Date(dateObj);
+  const [hh, mm] = startTime.split(':').map(Number);
+  start.setHours(hh, mm, 0, 0);
+  return start - last >= 12 * 60 * 60 * 1000;
+}
+
+function buildRoster(options = {}) {
+  const {
+    starters: rawStarters,
+    blocks,
+    welcomeDay = 2,
+    onboardDay = 3,
+    shuffle = false,
+    minShifts = DEFAULT_MIN_SHIFTS
+  } = options;
+
+  if (welcomeDay < 0 || welcomeDay > 6 || onboardDay < 0 || onboardDay > 6) {
+    throw new Error('welcomeDay and onboardDay must be between 0 (Sunday) and 6 (Saturday).');
+  }
+
+  const starters = sanitizeStarters(rawStarters);
+  const blockMap = sanitizeBlocks(blocks);
+  const allRows = [];
+  const placedByStarter = new Map();
+  const placedByStarterOutlet = new Map();
+  const usedSlots = new Set();
+
+  function incPlaced(starterName, outlet) {
+    placedByStarter.set(starterName, (placedByStarter.get(starterName) || 0) + 1);
+    if (!placedByStarterOutlet.has(starterName)) {
+      placedByStarterOutlet.set(starterName, new Map());
+    }
+    const outletMap = placedByStarterOutlet.get(starterName);
+    outletMap.set(outlet, (outletMap.get(outlet) || 0) + 1);
+  }
+
+  function getPlaced(starterName) {
+    return placedByStarter.get(starterName) || 0;
+  }
+
+  function getPlacedOutlet(starterName, outlet) {
+    return placedByStarterOutlet.get(starterName)?.get(outlet) || 0;
+  }
+
+  function addRow(row) {
+    allRows.push(row);
+    incPlaced(row.Starter, row.Outlet);
+  }
+
+  const normalized = starters.map((starter) => {
+    const norm = parseYMD(starter.StartDate);
+    while (isSun(norm)) {
+      norm.setDate(norm.getDate() + 1);
+    }
+    return { ...starter, NormStart: norm };
+  });
+
+  const groups = {};
+  for (const starter of normalized) {
+    const key = toYMD(starter.NormStart);
+    if (!groups[key]) groups[key] = [];
+    groups[key].push({ ...starter, blackoutDates: [...starter.blackoutDates] });
+  }
+
+  const sortedKeys = Object.keys(groups).sort();
+  for (const dayKey of sortedKeys) {
+    const welcomeDate = nextDow(parseYMD(dayKey), welcomeDay);
+    const onboardingDate = nextDow(welcomeDate, onboardDay, false);
+    for (const starter of groups[dayKey]) {
+      addRow(makeRow(starter, welcomeDate, MANDATORY_SESSIONS[0].start, MANDATORY_SESSIONS[0].label, 1));
+      addRow(makeRow(starter, onboardingDate, MANDATORY_SESSIONS[1].start, MANDATORY_SESSIONS[1].label, 2));
+      starter.__state = {
+        currentOutlet: null,
+        remaining: 0,
+        nextDate: addWorkDay(onboardingDate)
+      };
+    }
+  }
+
+  const conflicts = {
+    outletConflicts: 0,
+    dateConflicts: 0,
+    fallbackUsed: 0,
+    safetyTriggered: false
+  };
+
+  const everyone = sortedKeys.flatMap((key) => groups[key]);
+  let progress = true;
+  let safety = 0;
+
+  while (progress && safety < 5000) {
+    progress = false;
+    safety += 1;
+    if (safety > 4000) conflicts.safetyTriggered = true;
+
+    for (const starter of everyone) {
+      if (getPlaced(starter.Name) >= minShifts) {
+        starter.__state = null;
+        continue;
+      }
+      if (!starter.__state) continue;
+
+      const state = starter.__state;
+      let currentDate = nextWorking(state.nextDate);
+      let currentKey = toYMD(currentDate);
+      let outlet = state.currentOutlet;
+
+      if (state.remaining <= 0) {
+        let candidates = Object.keys(blockMap).filter((o) => getPlacedOutlet(starter.Name, o) < blockMap[o]);
+        if (!candidates.length) {
+          starter.__state = null;
+          continue;
+        }
+        if (shuffle) {
+          candidates = shuffleArray(candidates);
+        }
+        const allowedToday = candidates.filter((o) => !usedSlots.has(`${currentKey}|${o}`) && isOutletAllowedOnDate(o, currentDate));
+        if (!allowedToday.length) conflicts.outletConflicts += 1;
+        outlet = allowedToday[0] || (shuffle ? shuffleArray(candidates)[0] : candidates[0]);
+        state.currentOutlet = outlet;
+        state.remaining = Math.max(0, blockMap[outlet] - getPlacedOutlet(starter.Name, outlet));
+      }
+
+      const initialDate = currentDate;
+      let guard = 0;
+      while (
+        starter.blackoutDates.includes(currentKey) ||
+        usedSlots.has(`${currentKey}|${outlet}`) ||
+        !isOutletAllowedOnDate(outlet, currentDate) ||
+        !canWorkThisDay(allRows, starter.Name, currentDate) ||
+        !hasMinRest(allRows, starter.Name, currentDate, pickTime(outlet, allRows.length))
+      ) {
+        currentDate = addWorkDay(currentDate);
+        currentKey = toYMD(currentDate);
+        guard += 1;
+        if (guard > 100) break;
+      }
+
+      if (currentDate > initialDate) conflicts.dateConflicts += 1;
+      const startTime = pickTime(outlet, allRows.length);
+      addRow(makeRow(starter, currentDate, startTime, outlet, getPlaced(starter.Name) + 1));
+      usedSlots.add(`${currentKey}|${outlet}`);
+      state.remaining -= 1;
+      state.nextDate = addWorkDay(currentDate);
+      progress = true;
+    }
+  }
+
+  for (const starter of everyone) {
+    let placed = getPlaced(starter.Name);
+    if (placed >= minShifts) continue;
+    let last = allRows.filter((row) => row.Starter === starter.Name).map((row) => row.Date).sort().pop();
+    let current = last ? addWorkDay(parseYMD(last)) : nextWorking(starter.NormStart);
+    let rotation = 0;
+    let guard = 0;
+    const preferences = ['SOV South Floor', 'SOV South Bar', 'Oasis Food', 'Oasis Bar', 'SOV North Floor', 'SOV Dining'];
+    let fallbackNeeded = false;
+
+    while (placed < minShifts && guard < 5000) {
+      guard += 1;
+      const key = toYMD(current);
+      if (starter.blackoutDates.includes(key)) {
+        current = addWorkDay(current);
+        continue;
+      }
+      let outlet = preferences.find((o) =>
+        (!usedSlots.has(`${key}|${o}`)) &&
+        isOutletAllowedOnDate(o, current) &&
+        canWorkThisDay(allRows, starter.Name, current) &&
+        hasMinRest(allRows, starter.Name, current, pickTime(o, rotation))
+      );
+
+      if (!outlet) {
+        current = addWorkDay(current);
+        fallbackNeeded = true;
+        continue;
+      }
+
+      const startTime = pickTime(outlet, rotation++);
+      addRow(makeRow(starter, current, startTime, outlet, getPlaced(starter.Name) + 1));
+      usedSlots.add(`${key}|${outlet}`);
+      placed += 1;
+      current = addWorkDay(current);
+    }
+
+    if (fallbackNeeded) conflicts.fallbackUsed += 1;
+  }
+
+  allRows.sort((a, b) =>
+    a.Starter.localeCompare(b.Starter) ||
+    a.Date.localeCompare(b.Date) ||
+    a.Start.localeCompare(b.Start)
+  );
+
+  const totalConflicts = conflicts.outletConflicts + conflicts.dateConflicts + conflicts.fallbackUsed;
+  let summary = `Built ${allRows.length} shifts for ${starters.length} starter(s)`;
+  if (totalConflicts > 0) {
+    const parts = [];
+    if (conflicts.outletConflicts > 0) parts.push(`${conflicts.outletConflicts} outlet conflicts`);
+    if (conflicts.dateConflicts > 0) parts.push(`${conflicts.dateConflicts} scheduling conflicts`);
+    if (conflicts.fallbackUsed > 0) parts.push(`${conflicts.fallbackUsed} fallback shifts`);
+    if (conflicts.safetyTriggered) parts.push('complex scheduling');
+    summary += ` • Resolved: ${parts.join(', ')}`;
+  }
+
+  return {
+    rows: allRows,
+    conflicts,
+    summary,
+    stats: {
+      starters: starters.length,
+      minShifts,
+      welcomeDay,
+      onboardDay
+    }
+  };
+}
+
+function shuffleArray(values) {
+  const arr = values.slice();
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+module.exports = {
+  buildRoster,
+  sanitizeBlocks,
+  sanitizeStarters,
+  DEFAULT_MIN_SHIFTS,
+  DEFAULT_BLOCKS,
+  MANDATORY_SESSIONS
+};

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const express = require('express');
+const cors = require('cors');
+const { buildRoster, DEFAULT_MIN_SHIFTS, DEFAULT_BLOCKS, sanitizeBlocks, sanitizeStarters } = require('./rosterEngine');
+
+const app = express();
+app.use(cors());
+app.use(express.json({ limit: '1mb' }));
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/api/roster', (req, res) => {
+  try {
+    const { starters, blocks, welcomeDay, onboardDay, shuffle, minShifts } = req.body || {};
+    const sanitizedStarters = sanitizeStarters(starters);
+    const sanitizedBlocks = sanitizeBlocks(blocks);
+
+    const roster = buildRoster({
+      starters: sanitizedStarters,
+      blocks: sanitizedBlocks,
+      welcomeDay: typeof welcomeDay === 'number' ? welcomeDay : undefined,
+      onboardDay: typeof onboardDay === 'number' ? onboardDay : undefined,
+      shuffle: Boolean(shuffle),
+      minShifts: typeof minShifts === 'number' && minShifts > 0 ? Math.floor(minShifts) : undefined
+    });
+
+    res.json({
+      data: roster,
+      meta: {
+        defaults: {
+          minShifts: DEFAULT_MIN_SHIFTS,
+          blocks: DEFAULT_BLOCKS
+        }
+      }
+    });
+  } catch (error) {
+    res.status(400).json({
+      error: error.message
+    });
+  }
+});
+
+const PORT = Number(process.env.PORT) || 3001;
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Roster backend listening on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,859 @@
     "": {
       "name": "pgr-new-starter-roster-tool",
       "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "express": "^5.1.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,13 @@
   "version": "1.0.0",
   "description": "PGR New Starter Roster Tool",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "start:backend": "node backend/server.js"
   },
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^5.1.0"
+  }
 }

--- a/test/rosterEngine.test.js
+++ b/test/rosterEngine.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  buildRoster,
+  sanitizeStarters,
+  DEFAULT_MIN_SHIFTS,
+  MANDATORY_SESSIONS
+} = require('../backend/rosterEngine');
+
+test('buildRoster generates mandatory sessions and honours blackout days', () => {
+  const starters = [
+    { Name: 'Taylor Rivers', StartDate: '2025-01-07', blackoutDates: ['2025-01-09'] }
+  ];
+
+  const result = buildRoster({
+    starters,
+    blocks: {
+      'Oasis Food': 1,
+      'Oasis Bar': 0,
+      'SOV South Floor': 3,
+      'SOV North Floor': 0,
+      'SOV South Bar': 0,
+      'SOV Dining': 0
+    },
+    minShifts: 3
+  });
+
+  const rows = result.rows.filter((row) => row.Starter === 'Taylor Rivers');
+  assert.equal(rows.length, MANDATORY_SESSIONS.length + 1);
+
+  const mandatoryLabels = new Set(MANDATORY_SESSIONS.map((session) => session.label));
+  for (const label of mandatoryLabels) {
+    assert.ok(rows.some((row) => row.Outlet === label), `missing mandatory session ${label}`);
+  }
+
+  assert.ok(!rows.some((row) => row.Date === '2025-01-09'), 'scheduled on blackout date');
+  assert.ok(rows.some((row) => row.Date === '2025-01-10'), 'did not reschedule after blackout');
+});
+
+test('sanitizeStarters validates required fields', () => {
+  assert.throws(() => sanitizeStarters([]), /At least one starter/);
+  assert.throws(() => sanitizeStarters([{ Name: 'No Date' }]), /missing StartDate/);
+
+  const [sanitized] = sanitizeStarters([{ Name: 'Valid Starter', StartDate: '2025-02-04', blackoutDates: ['2025-02-05'] }]);
+  assert.equal(sanitized.Name, 'Valid Starter');
+  assert.equal(sanitized.blackoutDates.length, 1);
+  assert.equal(sanitized.blackoutDates[0], '2025-02-05');
+});
+
+test('buildRoster defaults produce a summary with the starter count', () => {
+  const starters = [
+    { Name: 'Alex Johnson', StartDate: '2025-01-07' },
+    { Name: 'Jordan Smith', StartDate: '2025-01-08' }
+  ];
+
+  const result = buildRoster({ starters });
+  assert.ok(result.summary.includes('2 starter'), 'summary should include starter count');
+  const alexRows = result.rows.filter((row) => row.Starter === 'Alex Johnson');
+  assert.ok(alexRows.length >= DEFAULT_MIN_SHIFTS, 'Alex should receive the minimum number of shifts');
+});


### PR DESCRIPTION
## Summary
- add a backend roster engine module to share scheduling logic outside the browser
- expose an Express API with validation for roster builds and health checks
- extend automated coverage for the roster engine and ignore vendored node modules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd4cd15708832aa265858f013ede33