### PR TITLE
Switch app typography to Plus Jakarta Sans & Playfair Display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-PGR Roster Creator - v7.0
+PGR Roster Creator - v10.5
 Created by Patrick Price 2025
 
 A professional, single-file web application designed to rapidly and intelligently generate training rosters for new team members in the Private Gaming Rooms (PGR) at The Star Gold Coast. This tool is built to be intuitive for supervisors, requiring no technical expertise to operate.

--- a/index.html
+++ b/index.html
@@ -12,14 +12,13 @@
   <link rel="icon" sizes="512x512" href="https://placehold.co/512x512/png">
 
   <style>
-    /* --- Modern Font: Inter --- */
-    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-    @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap');
+    /* --- Signature Typeface Palette --- */
+    @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Playfair+Display:wght@500;600;700&display=swap');
 
     /* --- CSS Variables & Base Styles --- */
     :root {
-      --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
-      --font-serif: 'Cinzel', serif;
+      --font-sans: 'Plus Jakarta Sans', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+      --font-serif: 'Playfair Display', 'Times New Roman', serif;
 
       --bg-primary: #0e0e0e;
       --bg-secondary: #181818;
@@ -139,7 +138,7 @@
         <div class="subbrand">Private Gaming Rooms</div>
         <div class="tagline">Let's train some newbies!</div>
         <div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Created by Patrick Price 2025</div>
-        <div style="font-size: 10px; color: var(--text-muted); margin-top: 2px;">Version 7.0</div>
+        <div style="font-size: 10px; color: var(--text-muted); margin-top: 2px;">Version 10.5</div>
       </div>
     </div>
     <div class="nav-group">


### PR DESCRIPTION
## Summary
- replace the previous Inter/Cinzel pairing with Plus Jakarta Sans and Playfair Display for the global UI typography

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de0635bddc832a8f892e08c2d89ae4